### PR TITLE
feat: Align Business Service DB interactions with docs

### DIFF
--- a/services/business-service/prisma/schema.prisma
+++ b/services/business-service/prisma/schema.prisma
@@ -19,10 +19,10 @@ model Business {
   website     String?
   phone       String?
   email       String
-  timezone    String
+  timezone    String   @default("UTC")
   currency    String   @default("USD")
   ownerId     String
-  status      String @default("PENDING_SETUP")
+  status      String   @default("PENDING_SETUP")
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
@@ -34,41 +34,41 @@ model Business {
   country    String
 
   // Settings (JSON fields stored as String for SQLite compatibility)
-  bookingSettings     String @default("{}")
-  paymentSettings     String @default("{}")
+  bookingSettings      String @default("{}")
+  paymentSettings      String @default("{}")
   notificationSettings String @default("{}")
   availabilitySettings String @default("{}")
 
   // Subscription
-  subscriptionPlan   String @default("FREE")
-  subscriptionStatus String @default("ACTIVE")
-  currentPeriodStart DateTime           @default(now())
-  currentPeriodEnd   DateTime           @default(now())
-  cancelAtPeriodEnd  Boolean            @default(false)
+  subscriptionPlan   String   @default("FREE")
+  subscriptionStatus String   @default("ACTIVE")
+  currentPeriodStart DateTime @default(now())
+  currentPeriodEnd   DateTime @default(now())
+  cancelAtPeriodEnd  Boolean  @default(false)
 
   // Relations
-  services      Service[]
+  services       Service[]
   availabilities Availability[] // Added relation to Availability
 
   @@map("businesses")
 }
 
 model Service {
-  id                    String  @id @default(cuid())
-  businessId            String
-  name                  String
-  description           String?
-  duration              Int     // minutes
-  price                 Float
-  currency              String  @default("USD")
-  category              String?
-  isActive              Boolean @default(true)
-  maxAdvanceBookingDays Int     @default(30)
-  minAdvanceBookingHours Int    @default(1)
-  allowOnlinePayment    Boolean @default(true)
-  requiresApproval      Boolean @default(false)
-  createdAt             DateTime @default(now())
-  updatedAt             DateTime @updatedAt
+  id                     String   @id @default(cuid())
+  businessId             String
+  name                   String
+  description            String?
+  duration               Int // minutes
+  price                  Float
+  currency               String   @default("USD")
+  category               String?
+  isActive               Boolean  @default(true)
+  maxAdvanceBookingDays  Int      @default(30)
+  minAdvanceBookingHours Int      @default(1)
+  allowOnlinePayment     Boolean  @default(true)
+  requiresApproval       Boolean  @default(false)
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
 
   // Relations
   business Business @relation(fields: [businessId], references: [id], onDelete: Cascade)
@@ -77,13 +77,14 @@ model Service {
 }
 
 model Availability {
-  id          String    @id @default(cuid())
-  businessId  String
-  dayOfWeek   DayOfWeek // Use enum for days
-  startTime   String    // Store as HH:MM string in 24-hour format e.g., "09:00"
-  endTime     String    // Store as HH:MM string e.g., "17:00"
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  id           String    @id @default(cuid())
+  businessId   String
+  dayOfWeek    DayOfWeek // Use enum for days
+  startTime    String // Store as HH:MM string in 24-hour format e.g., "09:00"
+  endTime      String // Store as HH:MM string e.g., "17:00"
+  is_available Boolean   @default(true)
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
 
   // Relations
   business Business @relation(fields: [businessId], references: [id], onDelete: Cascade)

--- a/services/business-service/src/services/AvailabilityService.ts
+++ b/services/business-service/src/services/AvailabilityService.ts
@@ -14,7 +14,7 @@ export interface SetAvailabilityData {
 }
 
 export class AvailabilityService {
-  private prisma: PrismaClient;
+  private prisma: PrismaClient; // This remains as it's typed for the global prisma instance
 
   constructor() {
     this.prisma = prisma;
@@ -73,6 +73,7 @@ export class AvailabilityService {
             dayOfWeek: rule.dayOfWeek,
             startTime: rule.startTime,
             endTime: rule.endTime,
+            is_available: true, // MODIFIED: Explicitly set is_available
           })),
         });
       }
@@ -93,6 +94,7 @@ export class AvailabilityService {
           dayOfWeek: rule.dayOfWeek,
           startTime: rule.startTime,
           endTime: rule.endTime,
+          // Note: is_available from fullNewRules could also be mapped here if needed for the event
         })),
       };
       await natsConnection.publish('business.availability.updated', eventPayload);
@@ -126,7 +128,7 @@ export class AvailabilityService {
       where: { businessId: businessId },
       orderBy: [
         // Sort by day of week (requires mapping enum to sort order or handling in client)
-        { dayOfWeek: 'asc' }, // This will sort alphabetically by enum name. Custom sort order might be needed.
+        { dayOfWeek: 'asc' },
         { startTime: 'asc' },
       ],
     });

--- a/services/business-service/src/services/__tests__/AvailabilityService.unit.test.ts
+++ b/services/business-service/src/services/__tests__/AvailabilityService.unit.test.ts
@@ -1,0 +1,169 @@
+import { AvailabilityService, SetAvailabilityData } from '../AvailabilityService';
+import { prisma } from '../../database/prisma';
+import { natsConnection } from '../../events/nats';
+import { Business, Availability, DayOfWeek, PrismaClient } from '@prisma/client';
+
+// Mock Prisma and NATS
+jest.mock('../../database/prisma', () => ({
+  prisma: {
+    business: {
+      findFirst: jest.fn(),
+    },
+    availability: {
+      deleteMany: jest.fn(),
+      createMany: jest.fn(),
+      findMany: jest.fn(),
+    },
+    $transaction: jest.fn().mockImplementation(async (callback) => {
+      // Simulate the transaction callback with a mock tx object
+      const mockTx = {
+        availability: {
+          deleteMany: jest.fn(),
+          createMany: jest.fn(),
+        },
+      };
+      await callback(mockTx);
+      // Make sure the mocked methods within the transaction are returned for assertions if needed
+      return {
+        deleteManyMock: mockTx.availability.deleteMany,
+        createManyMock: mockTx.availability.createMany,
+      };
+    }),
+  },
+}));
+
+jest.mock('../../events/nats', () => ({
+  natsConnection: {
+    publish: jest.fn(),
+  },
+}));
+
+describe('AvailabilityService', () => {
+  let availabilityService: AvailabilityService;
+  let mockPrismaTransaction: any; // To access mocks within $transaction
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    availabilityService = new AvailabilityService();
+
+    // Setup mock for $transaction to capture specific tx client mocks
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) => {
+      const mockTxClient = {
+        availability: {
+          deleteMany: jest.fn(),
+          createMany: jest.fn(),
+        },
+        // Add other models if they were part of a real transaction
+      };
+      await callback(mockTxClient);
+      mockPrismaTransaction = mockTxClient; // Store the mock client for assertions
+    });
+  });
+
+  describe('setAvailability', () => {
+    const businessId = 'test-business-id';
+    const userId = 'test-user-id';
+    const availabilityData: SetAvailabilityData = {
+      rules: [
+        { dayOfWeek: DayOfWeek.MONDAY, startTime: '09:00', endTime: '17:00' },
+        { dayOfWeek: DayOfWeek.TUESDAY, startTime: '10:00', endTime: '16:00' },
+      ],
+    };
+    const mockBusiness: Business = {
+      id: businessId,
+      ownerId: userId,
+      name: 'Test Business',
+      subdomain: 'test-sub',
+      status: 'ACTIVE',
+      timezone: 'UTC',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      description: null,
+      logo: null,
+      website: null,
+      phone: null,
+      email: 'business@example.com',
+      currency: 'USD',
+      street: '123 Main St',
+      city: 'Testville',
+      state: 'TS',
+      postalCode: '12345',
+      country: 'TC',
+      bookingSettings: '{}',
+      paymentSettings: '{}',
+      notificationSettings: '{}',
+      availabilitySettings: '{}',
+      subscriptionPlan: 'FREE',
+      subscriptionStatus: 'ACTIVE',
+      currentPeriodStart: new Date(),
+      currentPeriodEnd: new Date(),
+      cancelAtPeriodEnd: false,
+    };
+
+    const mockCreatedAvailabilities: Availability[] = availabilityData.rules.map(rule => ({
+      id: expect.any(String),
+      businessId,
+      ...rule,
+      is_available: true, // This is what we expect
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    it('should set availability rules and publish event, ensuring is_available is true', async () => {
+      (prisma.business.findFirst as jest.Mock).mockResolvedValue(mockBusiness);
+      (prisma.availability.findMany as jest.Mock).mockResolvedValue(mockCreatedAvailabilities);
+      // The actual createMany inside transaction will be asserted via mockPrismaTransaction
+
+      await availabilityService.setAvailability(businessId, userId, availabilityData);
+
+      expect(prisma.business.findFirst).toHaveBeenCalledWith({
+        where: { id: businessId, ownerId: userId },
+      });
+      expect(prisma.$transaction).toHaveBeenCalled();
+
+      // Assertions on the mocked transaction client
+      expect(mockPrismaTransaction.availability.deleteMany).toHaveBeenCalledWith({
+        where: { businessId: businessId },
+      });
+      expect(mockPrismaTransaction.availability.createMany).toHaveBeenCalledWith({
+        data: availabilityData.rules.map(rule => ({
+          businessId,
+          dayOfWeek: rule.dayOfWeek,
+          startTime: rule.startTime,
+          endTime: rule.endTime,
+          is_available: true, // Key assertion
+        })),
+      });
+
+      expect(prisma.availability.findMany).toHaveBeenCalledWith({
+        where: { businessId: businessId },
+        orderBy: [{ dayOfWeek: 'asc' }, { startTime: 'asc' }],
+      });
+
+      expect(natsConnection.publish).toHaveBeenCalledWith(
+        'business.availability.updated',
+        expect.objectContaining({
+          businessId,
+          rules: mockCreatedAvailabilities.map(r => ({ dayOfWeek: r.dayOfWeek, startTime: r.startTime, endTime: r.endTime})),
+        })
+      );
+    });
+
+    it('should throw error if business not found or user is not owner', async () => {
+      (prisma.business.findFirst as jest.Mock).mockResolvedValue(null);
+      await expect(
+        availabilityService.setAvailability(businessId, userId, availabilityData)
+      ).rejects.toThrow('Business not found or user is not the owner.');
+    });
+
+    it('should throw error for invalid rule format (e.g., startTime >= endTime)', async () => {
+      (prisma.business.findFirst as jest.Mock).mockResolvedValue(mockBusiness);
+      const invalidData: SetAvailabilityData = {
+        rules: [{ dayOfWeek: DayOfWeek.WEDNESDAY, startTime: '18:00', endTime: '17:00' }],
+      };
+      await expect(
+        availabilityService.setAvailability(businessId, userId, invalidData)
+      ).rejects.toThrow('Invalid availability rule: WEDNESDAY 18:00-17:00');
+    });
+  });
+});

--- a/services/business-service/src/services/__tests__/BusinessService.unit.test.ts
+++ b/services/business-service/src/services/__tests__/BusinessService.unit.test.ts
@@ -1,0 +1,125 @@
+import { BusinessService } from '../BusinessService';
+import { prisma } from '../../database/prisma';
+import { natsConnection } from '../../events/nats';
+import { Business, PrismaClient } from '@prisma/client'; // Keep PrismaClient for type if needed by mocks
+
+// Mock Prisma and NATS
+jest.mock('../../database/prisma', () => ({
+  prisma: {
+    business: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../events/nats', () => ({
+  natsConnection: {
+    publish: jest.fn(),
+  },
+}));
+
+jest.mock('nanoid', () => ({
+  nanoid: jest.fn(() => 'mocked-nanoid'),
+}));
+
+
+describe('BusinessService', () => {
+  let businessService: BusinessService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    businessService = new BusinessService(); // Constructor is now empty
+  });
+
+  describe('createBusiness', () => {
+    const ownerId = 'user-owner-id';
+    const createData = {
+      name: 'My Test Biz',
+      subdomain: 'testbiz',
+      email: 'test@biz.com',
+      street: '123 Test St',
+      city: 'Testville',
+      state: 'TS',
+      postalCode: '12345',
+      country: 'TC',
+      timezone: 'America/New_York', // Explicitly provide, db default is UTC
+      currency: 'USD',
+      ownerId,
+    };
+
+    const mockCreatedBusiness: Business = {
+      id: 'generated-biz-id',
+      ...createData,
+      status: 'PENDING_SETUP', // default from service logic
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      description: null,
+      logo: null,
+      website: null,
+      phone: null,
+      // other fields with defaults or null
+      bookingSettings: '{}',
+      paymentSettings: '{}',
+      notificationSettings: '{}',
+      availabilitySettings: '{}',
+      subscriptionPlan: 'FREE',
+      subscriptionStatus: 'ACTIVE',
+      currentPeriodStart: new Date(),
+      currentPeriodEnd: new Date(),
+      cancelAtPeriodEnd: false,
+    };
+
+    it('should create a business and publish an event', async () => {
+      (prisma.business.findUnique as jest.Mock).mockResolvedValue(null);
+      (prisma.business.create as jest.Mock).mockResolvedValue(mockCreatedBusiness);
+
+      const result = await businessService.createBusiness(createData);
+
+      expect(prisma.business.findUnique).toHaveBeenCalledWith({
+        where: { subdomain: createData.subdomain },
+      });
+      expect(prisma.business.create).toHaveBeenCalledWith({
+        data: {
+          name: createData.name,
+          description: undefined, // from interface
+          subdomain: createData.subdomain,
+          email: createData.email,
+          phone: undefined, // from interface
+          website: undefined, // from interface
+          street: createData.street,
+          city: createData.city,
+          state: createData.state,
+          postalCode: createData.postalCode,
+          country: createData.country,
+          timezone: createData.timezone,
+          currency: createData.currency,
+          ownerId: createData.ownerId,
+          status: 'PENDING_SETUP',
+        },
+      });
+      expect(natsConnection.publish).toHaveBeenCalledWith(
+        'slotwise.business.created', // Ensure prefix is correct as per publishEvent
+        expect.objectContaining({
+          id: 'mocked-nanoid', // from mocked nanoid
+          type: 'business.created',
+          source: 'business-service',
+          data: {
+            businessId: mockCreatedBusiness.id,
+            name: mockCreatedBusiness.name,
+            subdomain: mockCreatedBusiness.subdomain,
+            ownerId: mockCreatedBusiness.ownerId,
+          },
+        })
+      );
+      expect(result).toEqual(mockCreatedBusiness);
+    });
+
+    it('should throw error if subdomain already exists', async () => {
+      (prisma.business.findUnique as jest.Mock).mockResolvedValue(mockCreatedBusiness); // Simulate existing
+      await expect(businessService.createBusiness(createData)).rejects.toThrow(
+        'Subdomain already exists'
+      );
+    });
+  });
+});


### PR DESCRIPTION
- I updated `prisma/schema.prisma` for Business Service:
    - Added `is_available: Boolean @default(true)` to the `Availability` model.
    - Added `@default("UTC")` to the `timezone` field in the `Business` model. This aligns the schema with the details specified in architecture documentation.

- I refactored `AvailabilityService` to explicitly set `is_available: true` when creating new availability rules.

- I refactored `BusinessService` to use globally imported `prisma` client and `natsConnection` for consistency, removing them from constructor injection.

- I added new unit tests for `AvailabilityService` and `BusinessService`:
    - `AvailabilityService.unit.test.ts` verifies the `is_available` logic during `setAvailability` and event publishing.
    - `BusinessService.unit.test.ts` verifies `createBusiness` behavior post-refactor, including calls to Prisma and NATS.

Note: Database migration SQL generation (`prisma migrate dev`) was skipped due to environment limitations but the schema itself is updated.